### PR TITLE
Add approach to prevent getting stuck in run-containers.md

### DIFF
--- a/language/python/run-containers.md
+++ b/language/python/run-containers.md
@@ -57,6 +57,11 @@ Success! We were able to connect to the application running inside of our contai
 ```
 
 Press ctrl-c to stop the container.
+> **Note**
+>
+> If ctrl-c does not stop the container, then you can stop it from within Docker Desktop:
+> Switch to the Docker Desktop application and click on _Containers / Apps_ in the top left corner.
+> Hover over your _RUNNING_ Container _python-docker_ on _Port: 5000_ and klick on the _STOP_ button on the right-hand side.
 
 ## Run in detached mode
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you  go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

ctrl-c does not work after running the container in non-detached mode.
Therefore I added a note to stop the container from within Docker Desktop.

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

[ctrl-c can't stop the container](https://github.com/docker/docker.github.io/issues/13133)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
