### PR TITLE
Delete backslashes in code of develop.md

### DIFF
--- a/language/python/develop.md
+++ b/language/python/develop.md
@@ -39,12 +39,7 @@ Now we can run MySQL in a container and attach to the volumes and network we cre
 In the following command, option `-v` is for starting the container with volumes. For more information, see [Docker volumes](../../storage/volumes.md).
 
 ```shell
-$ docker run --rm -d -v mysql:/var/lib/mysql \
-  -v mysql_config:/etc/mysql -p 3306:3306 \
-  --network mysqlnet \
-  --name mysqldb \
-  -e MYSQL_ROOT_PASSWORD=p@ssw0rd1 \
-  mysql
+$ docker run --rm -d -v mysql:/var/lib/mysql -v mysql_config:/etc/mysql -p 3306:3306 --network mysqlnet --name mysqldb -e MYSQL_ROOT_PASSWORD=p@ssw0rd1 mysql
 ```
 
 Now, let’s make sure that our MySQL database is running and that we can connect to it. Connect to the running MySQL database inside the container using the following command and enter "p@ssw0rd1" when prompted for the password:
@@ -159,12 +154,7 @@ $ docker build --tag python-docker .
 Now, let’s add the container to the database network and then run our container. This allows us to access the database by its container name.
 
 ```shell
-$ docker run \
-  --rm -d \
-  --network mysqlnet \
-  --name rest-server \
-  -p 5000:5000 \
-  python-docker
+$ docker run --rm -d --network mysqlnet --name rest-server -p 5000:5000 python-docker
 ```
 
 Let’s test that our application is connected to the database and is able to add a note.


### PR DESCRIPTION
### Proposed changes

I deleted the backslashes in two code sections (which where meant to escape the newline - as far as I know).
It is not possible to write and use the code as described (with the backslashes) - at least in my case of Windows CMD.
With the changes one can now see actually usable code, which one can just copy and paste - even if one does not know that the backslashes must be deleted before.
I don't think the backslashes make it easier to understand these parts.
For deeper understanding however the [volumes page](https://docs.docker.com/storage/volumes/) is already [referenced before.](https://docs.docker.com/language/python/develop/#run-a-database-in-a-container)

### Unreleased project version (optional)

### Related issues (optional)

[ Backslashes (to escape newline) in code boxes make code unusable #13136](https://github.com/docker/docker.github.io/issues/13136)